### PR TITLE
Adds functionality to grinder storage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.30'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.6.36.2'
+def runeLiteVersion = '1.8.30'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterConfig.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterConfig.java
@@ -4,9 +4,11 @@ import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 
-@ConfigGroup("sandstonebucketscounter")
+@ConfigGroup(SandstoneBucketsCounterConfig.CONFIG_GROUP_NAME)
 public interface SandstoneBucketsCounterConfig extends Config
 {
+	String CONFIG_GROUP_NAME = "sandstonebucketscounter";
+
 	@ConfigItem(
 		keyName = "showOverlay",
 		name = "Show Overlay",

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
@@ -50,6 +50,17 @@ class SandstoneBucketsCounterOverlay extends OverlayPanel
 			.left("(inventory)")
 			.build());
 
+		panelComponent.getChildren().add(TitleComponent.builder()
+				.text("Grinder")
+				.color(Color.ORANGE)
+				.build());
+
+		int grinderCount = plugin.getGrinderCount() > 0 ? plugin.getGrinderCount() : 0;
+		panelComponent.getChildren().add(LineComponent.builder()
+				.left("Buckets of sand:")
+				.right(Integer.toString(grinderCount))
+				.build());
+
 
 		return super.render(graphics);
 	}

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
@@ -5,7 +5,6 @@ import javax.inject.Inject;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
 
-import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -16,9 +15,6 @@ class SandstoneBucketsCounterOverlay extends OverlayPanel
 {
 	private final SandstoneBucketsCounterPlugin plugin;
 	private final SandstoneBucketsCounterConfig sandstoneBucketsCounterConfig;
-
-	private static final Font BOLD_FONT = FontManager.getRunescapeBoldFont();
-	private static final Font NORMAL_FONT = FontManager.getRunescapeFont();
 
 	@Inject
 	private SandstoneBucketsCounterOverlay(SandstoneBucketsCounterPlugin plugin, SandstoneBucketsCounterConfig sandstoneBucketsCounterConfig)
@@ -38,13 +34,10 @@ class SandstoneBucketsCounterOverlay extends OverlayPanel
 			return null;
 		}
 
-		graphics.setFont(BOLD_FONT);
 		panelComponent.getChildren().add(TitleComponent.builder()
 			.text("Buckets of sand")
 			.color(Color.ORANGE)
 			.build());
-
-		graphics.setFont(NORMAL_FONT);
 
 		int inventoryCount = plugin.getInventoryCount() > 0 ? plugin.getInventoryCount() : 0;
 		panelComponent.getChildren().add(LineComponent.builder()

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterOverlay.java
@@ -1,11 +1,11 @@
 package net.klisiu.sandstonebucketscounter;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics2D;
+import java.awt.*;
 import javax.inject.Inject;
 import static net.runelite.api.MenuAction.RUNELITE_OVERLAY_CONFIG;
 import static net.runelite.client.ui.overlay.OverlayManager.OPTION_CONFIGURE;
+
+import net.runelite.client.ui.FontManager;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -16,6 +16,9 @@ class SandstoneBucketsCounterOverlay extends OverlayPanel
 {
 	private final SandstoneBucketsCounterPlugin plugin;
 	private final SandstoneBucketsCounterConfig sandstoneBucketsCounterConfig;
+
+	private static final Font BOLD_FONT = FontManager.getRunescapeBoldFont();
+	private static final Font NORMAL_FONT = FontManager.getRunescapeFont();
 
 	@Inject
 	private SandstoneBucketsCounterOverlay(SandstoneBucketsCounterPlugin plugin, SandstoneBucketsCounterConfig sandstoneBucketsCounterConfig)
@@ -35,29 +38,23 @@ class SandstoneBucketsCounterOverlay extends OverlayPanel
 			return null;
 		}
 
+		graphics.setFont(BOLD_FONT);
 		panelComponent.getChildren().add(TitleComponent.builder()
-			.text("Sandstones mining")
+			.text("Buckets of sand")
 			.color(Color.ORANGE)
 			.build());
 
+		graphics.setFont(NORMAL_FONT);
+
 		int inventoryCount = plugin.getInventoryCount() > 0 ? plugin.getInventoryCount() : 0;
 		panelComponent.getChildren().add(LineComponent.builder()
-			.left("Buckets of sand:")
+			.left("Inventory:")
 			.right(Integer.toString(inventoryCount))
 			.build());
 
-		panelComponent.getChildren().add(LineComponent.builder()
-			.left("(inventory)")
-			.build());
-
-		panelComponent.getChildren().add(TitleComponent.builder()
-				.text("Grinder")
-				.color(Color.ORANGE)
-				.build());
-
 		int grinderCount = plugin.getGrinderCount() > 0 ? plugin.getGrinderCount() : 0;
 		panelComponent.getChildren().add(LineComponent.builder()
-				.left("Buckets of sand:")
+				.left("Grinder:")
 				.right(Integer.toString(grinderCount))
 				.build());
 

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterPlugin.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterPlugin.java
@@ -41,6 +41,8 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 
 	private static final Pattern GRINDER_CHECK_BUCKET_PATTERN = Pattern.compile("I have (?<emptyBucketCount>[\\d,]+) of your buckets and you've ground enough sandstone for (?<filledBucketCount>[\\d,]+) buckets of sand.");
 
+	private static final String CONFIG_GRINDER_STORAGE_KEY = "numStoredInGrinder";
+
 	@Inject
 	private Client client;
 
@@ -51,12 +53,14 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 	private OverlayManager overlayManager;
 
 	@Inject
+	private ConfigManager configManager;
+
+	@Inject
 	private SandstoneBucketsCounterOverlay overlay;
 
 	@Getter(AccessLevel.PACKAGE)
 	private int inventoryCount;
 
-	@Getter(AccessLevel.PACKAGE)
 	private int grinderCount;
 
 	@Getter(AccessLevel.PACKAGE)
@@ -120,7 +124,7 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 
 		String npcText = Text.sanitizeMultilineText(npcDialog.getText());
 		Matcher textMatcher = GRINDER_DEPOSIT_BUCKET_PATTERN.matcher(npcText);
-		log.debug(npcText);
+
 		if (!textMatcher.find()) {
 			textMatcher = GRINDER_CHECK_BUCKET_PATTERN.matcher(npcText);
 			if (!textMatcher.find()) {
@@ -129,7 +133,12 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 		}
 
 		grinderCount = Integer.parseInt(textMatcher.group("filledBucketCount").replace(",", ""));
+		configManager.setRSProfileConfiguration(SandstoneBucketsCounterConfig.CONFIG_GROUP_NAME, CONFIG_GRINDER_STORAGE_KEY, grinderCount);
+	}
 
+	public int getGrinderCount() {
+		Integer configGrinderCount = configManager.getRSProfileConfiguration(SandstoneBucketsCounterConfig.CONFIG_GROUP_NAME, CONFIG_GRINDER_STORAGE_KEY, int.class);
+		return configGrinderCount != null ? configGrinderCount : grinderCount;
 	}
 
 	@Subscribe

--- a/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterPlugin.java
+++ b/src/main/java/net/klisiu/sandstonebucketscounter/SandstoneBucketsCounterPlugin.java
@@ -5,22 +5,27 @@ import javax.inject.Inject;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.Client;
-import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
-import net.runelite.api.ItemContainer;
+import net.runelite.api.*;
+
 import static net.runelite.api.ItemID.SANDSTONE_10KG;
 import static net.runelite.api.ItemID.SANDSTONE_1KG;
 import static net.runelite.api.ItemID.SANDSTONE_2KG;
 import static net.runelite.api.ItemID.SANDSTONE_5KG;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
+import net.runelite.api.widgets.Widget;
+import net.runelite.api.widgets.WidgetInfo;
+import net.runelite.api.widgets.WidgetModelType;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+import net.runelite.client.util.Text;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @PluginDescriptor(
 	name = "Sandstone Buckets Counter",
@@ -31,6 +36,10 @@ import net.runelite.client.ui.overlay.OverlayManager;
 public class SandstoneBucketsCounterPlugin extends Plugin
 {
 	private static final int DESERT_QUARRY_REGION = 12589;
+
+	private static final Pattern GRINDER_DEPOSIT_BUCKET_PATTERN = Pattern.compile("The grinder is now holding enough sandstone equivalent to (?<filledBucketCount>[\\d,]+) buckets of sand.");
+
+	private static final Pattern GRINDER_CHECK_BUCKET_PATTERN = Pattern.compile("I have (?<emptyBucketCount>[\\d,]+) of your buckets and you've ground enough sandstone for (?<filledBucketCount>[\\d,]+) buckets of sand.");
 
 	@Inject
 	private Client client;
@@ -46,6 +55,9 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 
 	@Getter(AccessLevel.PACKAGE)
 	private int inventoryCount;
+
+	@Getter(AccessLevel.PACKAGE)
+	private int grinderCount;
 
 	@Getter(AccessLevel.PACKAGE)
 	private boolean isInDesertQuarry;
@@ -88,6 +100,38 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 		return false;
 	}
 
+	private void getGrinderChatbox()
+	{
+		Widget npcDialog = client.getWidget(WidgetInfo.DIALOG_NPC_TEXT);
+		if (npcDialog == null) {
+			return;
+		}
+
+		Widget name = client.getWidget(WidgetInfo.DIALOG_NPC_NAME);
+		Widget head = client.getWidget(WidgetInfo.DIALOG_NPC_HEAD_MODEL);
+		if (name == null || head == null || head.getModelType() != WidgetModelType.NPC_CHATHEAD) {
+			return;
+		}
+
+		final int npcId = head.getModelId();
+		if (npcId != NpcID.DREW) {
+			return;
+		}
+
+		String npcText = Text.sanitizeMultilineText(npcDialog.getText());
+		Matcher textMatcher = GRINDER_DEPOSIT_BUCKET_PATTERN.matcher(npcText);
+		log.debug(npcText);
+		if (!textMatcher.find()) {
+			textMatcher = GRINDER_CHECK_BUCKET_PATTERN.matcher(npcText);
+			if (!textMatcher.find()) {
+				return;
+			}
+		}
+
+		grinderCount = Integer.parseInt(textMatcher.group("filledBucketCount").replace(",", ""));
+
+	}
+
 	@Subscribe
 	public void onGameTick(GameTick gameTick)
 	{
@@ -111,7 +155,11 @@ public class SandstoneBucketsCounterPlugin extends Plugin
 		}
 
 		isInDesertQuarry = true;
+
+		getGrinderChatbox();
 	}
+
+
 
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)


### PR DESCRIPTION
Adds similar functionality to the buckets stored in the grinder.

- Parses chatbox for Drew's (the sandstone grinder attendant) NPC text.
- Determines if it matches either the check or deposit pattern.
- Parses out the integer of buckets.
- Finally adds it to the overlay.

Fixes Issue: https://github.com/wookkeey/sandstone-buckets-counter/issues/2

Possible discussion around:
- Could format the overlay a little differently.
- Could use `configManager.[set/get]RSProfileConfiguration` to store the grinder count between client restarts.

Example:
![image](https://user-images.githubusercontent.com/39996391/183221099-b63340b8-7a8f-4142-8493-5fbc3e688311.png)
